### PR TITLE
Optimized oldBehaviors(for:), newBehaviors(for:) and shouldInvalidate…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/BouncyLayout.xcodeproj/project.xcworkspace/xcuserdata
+/BouncyLayout.xcodeproj/xcuserdata

--- a/BouncyLayout/Classes/BouncyLayout.swift
+++ b/BouncyLayout/Classes/BouncyLayout.swift
@@ -2,13 +2,15 @@ import UIKit
 
 public class BouncyLayout: UICollectionViewFlowLayout {
     
-    private lazy var animator: UIDynamicAnimator = { UIDynamicAnimator(collectionViewLayout: self) }()
+    private lazy var animator: UIDynamicAnimator = UIDynamicAnimator(collectionViewLayout: self)
     
     public override func prepare() {
         super.prepare()
-        guard let view = collectionView, let attributes = super.layoutAttributesForElements(in: view.bounds)?.flatMap({ $0.copy() as? UICollectionViewLayoutAttributes }) else { return }
+        guard let view = collectionView,
+            let attributes = super.layoutAttributesForElements(in: view.bounds)?
+                .flatMap({ $0.copy() as? UICollectionViewLayoutAttributes }) else { return }
         
-        oldBehaviors(for: attributes).forEach { animator.removeBehavior($0) }
+        oldBehaviors(for: attributes).forEach(animator.removeBehavior(_:))
         newBehaviors(for: attributes).forEach {
             $0.damping = 0.7
             $0.frequency = 1.5
@@ -17,15 +19,26 @@ public class BouncyLayout: UICollectionViewFlowLayout {
     }
     
     private func oldBehaviors(for attributes: [UICollectionViewLayoutAttributes]) -> [UIAttachmentBehavior] {
-        return animator.behaviors.flatMap { $0 as? UIAttachmentBehavior }.filter {
-            guard let item = $0.items.first as? UICollectionViewLayoutAttributes else { return false }
-            return !attributes.map { $0.indexPath }.contains(item.indexPath)
+        let indexPaths = attributes.map { $0.indexPath }
+        return animator.behaviors
+            .flatMap {
+                guard let behavior = $0 as? UIAttachmentBehavior,
+                    let itemAttributes = behavior.items.first as? UICollectionViewLayoutAttributes else { return nil }
+                return indexPaths.contains(itemAttributes.indexPath)
+                    ? nil
+                    : behavior
         }
     }
     
     private func newBehaviors(for attributes: [UICollectionViewLayoutAttributes]) -> [UIAttachmentBehavior] {
-        let indexPaths = animator.behaviors.flatMap { $0 as? UIAttachmentBehavior }.flatMap { $0.items.first as? UICollectionViewLayoutAttributes }.map { $0.indexPath }
-        return attributes.filter { return !indexPaths.contains($0.indexPath) }.map { UIAttachmentBehavior(item: $0, attachedToAnchor: $0.center) }
+        let indexPaths = animator.behaviors
+            .flatMap { (($0 as? UIAttachmentBehavior)?.items.first as? UICollectionViewLayoutAttributes)?.indexPath }
+        return attributes
+            .flatMap {
+                return indexPaths.contains($0.indexPath)
+                    ? nil
+                    : UIAttachmentBehavior(item: $0, attachedToAnchor: $0.center)
+        }
     }
     
     public override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -37,18 +50,27 @@ public class BouncyLayout: UICollectionViewFlowLayout {
     }
     
     public override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-        animator.behaviors.flatMap { $0 as? UIAttachmentBehavior }.forEach {
-            guard let view = collectionView, let item = $0.items.first else { return }
-            update(behavior: $0, and: item, in: view, for: newBounds)
+        guard let view = collectionView else { return false }
+        
+        animator.behaviors.forEach {
+            guard let behavior = $0 as? UIAttachmentBehavior,
+                let item = behavior.items.first else { return }
+            update(behavior: behavior, and: item, in: view, for: newBounds)
             animator.updateItem(usingCurrentState: item)
         }
-        return false
+        return view.bounds.width != newBounds.width
     }
     
     private func update(behavior: UIAttachmentBehavior, and item: UIDynamicItem, in view: UICollectionView, for bounds: CGRect) {
-        let delta = CGVector(dx: bounds.origin.x - view.bounds.origin.x, dy: bounds.origin.y - view.bounds.origin.y)
-        let resistance = CGVector(dx: fabs(view.panGestureRecognizer.location(in: view).x - behavior.anchorPoint.x) / 1000, dy: fabs(view.panGestureRecognizer.location(in: view).y - behavior.anchorPoint.y) / 1000)
-        item.center.y += delta.dy < 0 ? max(delta.dy, delta.dy * resistance.dy) : min(delta.dy, delta.dy * resistance.dy)
-        item.center.x += delta.dx < 0 ? max(delta.dx, delta.dx * resistance.dx) : min(delta.dx, delta.dx * resistance.dx)
+        let delta = CGVector(dx: bounds.origin.x - view.bounds.origin.x,
+                             dy: bounds.origin.y - view.bounds.origin.y)
+        let resistance = CGVector(dx: fabs(view.panGestureRecognizer.location(in: view).x - behavior.anchorPoint.x) / 1000,
+                                  dy: fabs(view.panGestureRecognizer.location(in: view).y - behavior.anchorPoint.y) / 1000)
+        item.center.y += delta.dy < 0
+            ? max(delta.dy, delta.dy * resistance.dy)
+            : min(delta.dy, delta.dy * resistance.dy)
+        item.center.x += delta.dx < 0
+            ? max(delta.dx, delta.dx * resistance.dx)
+            : min(delta.dx, delta.dx * resistance.dx)
     }
 }


### PR DESCRIPTION
Optimized oldBehaviors(for:), newBehaviors(for:) and shouldInvalidateLayout(forBoundsChange:)

While chaining multiple map, flatMap and filter calls makes the code very readable, a class that is meant to be used as a library should strive for performance. I have taken the liberty to optimise the aforementioned methods so they don't perform superfluous full passes over collections.

Also, now shouldInvalidateLayout(forBoundsChange:) returns the result of comparing the current bounds.width with the newBounds.width, so the layout can adapt to interface orientation or size class changes.