### PR TITLE
Update previews size

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![](art/header.png)
 
-<p float="left">
+<p float="center">
  	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="250">
 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="250">
 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="250">

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 ![](art/header.png)
-![](art/gifs/01.gif)![](art/gifs/02.gif)![](art/gifs/03.gif)
-
-![](art/header.png)
 
 <p float="center">
- 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="270">
-	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="270">
-	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="270">
+ 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="290">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="290">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="290">
 </p>
 
 **BouncyLayout** is a collection view layout that makes your cells bounce.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ![](art/header.png)
 
 <p float="center">
- 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="250">
-	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="250">
-	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="250">
+ 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="270">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="270">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="270">
 </p>
 
 **BouncyLayout** is a collection view layout that makes your cells bounce.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 ![](art/header.png)
 ![](art/gifs/01.gif)![](art/gifs/02.gif)![](art/gifs/03.gif)
 
+![](art/header.png)
+
+<p float="left">
+ 	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/01.gif" width="250">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/02.gif" width="250">
+	<img src="https://github.com/roberthein/BouncyLayout/blob/master/art/gifs/03.gif" width="250">
+</p>
+
 **BouncyLayout** is a collection view layout that makes your cells bounce.
 
 ## Features


### PR DESCRIPTION
For MacBook 13 and other - gifs not fit on one line. I set width in readme for each item `290`. 
See preview for details: 
![Artboard](https://user-images.githubusercontent.com/10995774/57770099-37c3a580-7718-11e9-9e9b-e6feab293559.jpg)