### PR TITLE
Performance + Detect Size Changes [Fixes: 24, 15, 6]

### DIFF
--- a/BouncyLayout.podspec
+++ b/BouncyLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'BouncyLayout'
-  s.version      = '2.2.0'
+  s.version      = '2.3.0'
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.summary      = 'Make. It. Bounce.'

--- a/BouncyLayout/Classes/BouncyLayout.swift
+++ b/BouncyLayout/Classes/BouncyLayout.swift
@@ -2,119 +2,159 @@ import Foundation
 import UIKit
 
 open class BouncyLayout: UICollectionViewFlowLayout {
+  
+  fileprivate let VIEWPORT_BUFFER: CGFloat = 200.0
+  
+  public enum BounceStyle {
+    case subtle
+    case regular
+    case prominent
     
-    public enum BounceStyle {
-        case subtle
-        case regular
-        case prominent
-        
-        var damping: CGFloat {
-            switch self {
-            case .subtle: return 0.8
-            case .regular: return 0.7
-            case .prominent: return 0.5
-            }
+    var damping: CGFloat {
+      switch self {
+      case .subtle:     return 0.8
+      case .regular:    return 0.7
+      case .prominent:  return 0.5
+      }
+    }
+    
+    var frequency: CGFloat {
+      switch self {
+      case .subtle:     return 2
+      case .regular:    return 1.5
+      case .prominent:  return 1
+      }
+    }
+  }
+  
+  private var damping: CGFloat = BounceStyle.regular.damping
+  private var frequency: CGFloat = BounceStyle.regular.frequency
+  
+  // updateItem doesn't take into account size changes
+  // so we track visible size changes and re-prepare
+  // behaviors on change
+  private var visibleItemsSizeCache: [IndexPath:CGSize] = [:]
+  private var visibleIndexPaths: Set<IndexPath> = Set()
+  
+  private lazy var animator: UIDynamicAnimator = UIDynamicAnimator(collectionViewLayout: self)
+  
+  public convenience init(style: BounceStyle) {
+    self.init()
+    
+    damping = style.damping
+    frequency = style.frequency
+  }
+  
+  public convenience init(damping: CGFloat, frequency: CGFloat) {
+    self.init()
+    
+    self.damping = damping
+    self.frequency = frequency
+  }
+  
+  open override func prepare() {
+    super.prepare()
+    
+    // Give viewport directional buffer
+    // to account for fast scrolling
+    guard let view = collectionView,
+      let items = super.layoutAttributesForElements(in:
+        view.bounds.insetBy(dx: -VIEWPORT_BUFFER,
+                            dy: -VIEWPORT_BUFFER))
+      else { return }
+    
+    let indexPathsForRange = Set(items.map { $0.indexPath })
+    
+    // Remove items that aren't in viewport
+    for behavior in animator.behaviors {
+      if let behavior = behavior as? UIAttachmentBehavior {
+        guard let firstItem = behavior.items.first as? UICollectionViewLayoutAttributes else {
+          continue
         }
-        
-        var frequency: CGFloat {
-            switch self {
-            case .subtle: return 2
-            case .regular: return 1.5
-            case .prominent: return 1
-            }
+        if !indexPathsForRange.contains(firstItem.indexPath) {
+          animator.removeBehavior(behavior)
+          visibleIndexPaths.remove(firstItem.indexPath)
+          visibleItemsSizeCache.removeValue(forKey: firstItem.indexPath)
         }
+      }
     }
     
-    private var damping: CGFloat = BounceStyle.regular.damping
-    private var frequency: CGFloat = BounceStyle.regular.frequency
-    
-    public convenience init(style: BounceStyle) {
-        self.init()
-        
-        damping = style.damping
-        frequency = style.frequency
+    // Add missing items that are in viewport
+    // If there has been a cell size change
+    // then reset behaviors for viewport cells
+    for item in items {
+      if !visibleIndexPaths.contains(item.indexPath) {
+        addItem(item, in: view)
+      } else if visibleItemsSizeCache[item.indexPath]?.equalTo(item.size) == false {
+        animator.removeAllBehaviors()
+        visibleIndexPaths.removeAll()
+        items.forEach { addItem($0, in: view) }
+        break
+      }
+    }
+  }
+  
+  private func addItem(_ item: UICollectionViewLayoutAttributes, in view: UICollectionView) {
+    let behavior = UIAttachmentBehavior(item: item, attachedToAnchor: floor(item.center))
+    animator.addBehavior(behavior, damping, frequency)
+    visibleIndexPaths.insert(item.indexPath)
+    visibleItemsSizeCache[item.indexPath] = item.bounds.size
+  }
+  
+  private func addItem(_ item: UIDynamicItem, in view: UICollectionView) {
+    guard let item = item as? UICollectionViewLayoutAttributes else {
+      return
     }
     
-    public convenience init(damping: CGFloat, frequency: CGFloat) {
-        self.init()
-        
-        self.damping = damping
-        self.frequency = frequency
+    addItem(item, in: view)
+  }
+  
+  open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+    return animator.items(in: rect) as? [UICollectionViewLayoutAttributes]
+  }
+  
+  open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+    return animator.layoutAttributesForCell(at: indexPath) ?? super.layoutAttributesForItem(at: indexPath)
+  }
+  
+  open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    guard let view = collectionView else { return false }
+    
+    animator.behaviors.forEach {
+      guard let behavior = $0 as? UIAttachmentBehavior,
+        let item = behavior.items.first else {
+          return
+      }
+      update(behavior: behavior, and: item, in: view, for: newBounds)
+      animator.updateItem(usingCurrentState: item)
     }
     
-    private lazy var animator: UIDynamicAnimator = UIDynamicAnimator(collectionViewLayout: self)
+    return false // animator will automatically notify FlowLayout to invalidate
+  }
+  
+  private func update(behavior: UIAttachmentBehavior, and item: UIDynamicItem, in view: UICollectionView, for bounds: CGRect) {
+    let delta = CGVector(dx: bounds.origin.x - view.bounds.origin.x, dy: bounds.origin.y - view.bounds.origin.y)
+    let resistance = CGVector(dx: abs(view.panGestureRecognizer.location(in: view).x - behavior.anchorPoint.x) / 1000, dy: abs(view.panGestureRecognizer.location(in: view).y - behavior.anchorPoint.y) / 1000)
     
-    open override func prepare() {
-        super.prepare()
-        guard let view = collectionView, let attributes = super.layoutAttributesForElements(in: view.bounds.insetBy(dx: -200, dy: -200))?.compactMap({ $0.copy() as? UICollectionViewLayoutAttributes }) else { return }
-        
-        oldBehaviors(for: attributes).forEach { animator.removeBehavior($0) }
-        newBehaviors(for: attributes).forEach { animator.addBehavior($0, damping, frequency) }
+    switch scrollDirection {
+    case .horizontal: item.center.x += delta.dx < 0 ? max(delta.dx, delta.dx * resistance.dx) : min(delta.dx, delta.dx * resistance.dx)
+    case .vertical: item.center.y += delta.dy < 0 ? max(delta.dy, delta.dy * resistance.dy) : min(delta.dy, delta.dy * resistance.dy)
+    @unknown default:
+      item.center.y += delta.dy < 0 ? max(delta.dy, delta.dy * resistance.dy) : min(delta.dy, delta.dy * resistance.dy)
     }
     
-    private func oldBehaviors(for attributes: [UICollectionViewLayoutAttributes]) -> [UIAttachmentBehavior] {
-        let indexPaths = attributes.map { $0.indexPath }
-        return animator.behaviors.compactMap {
-            guard let behavior = $0 as? UIAttachmentBehavior, let itemAttributes = behavior.items.first as? UICollectionViewLayoutAttributes else { return nil }
-            return indexPaths.contains(itemAttributes.indexPath) ? nil : behavior
-        }
-    }
-    
-    private func newBehaviors(for attributes: [UICollectionViewLayoutAttributes]) -> [UIAttachmentBehavior] {
-        let indexPaths = animator.behaviors.compactMap { (($0 as? UIAttachmentBehavior)?.items.first as? UICollectionViewLayoutAttributes)?.indexPath }
-        return attributes.compactMap { indexPaths.contains($0.indexPath) ? nil : UIAttachmentBehavior(item: $0, attachedToAnchor: $0.center.floored()) }
-    }
-    
-    open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        return animator.items(in: rect) as? [UICollectionViewLayoutAttributes]
-    }
-    
-    open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        return animator.layoutAttributesForCell(at: indexPath) ?? super.layoutAttributesForItem(at: indexPath)
-    }
-    
-    open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-        guard let view = collectionView else { return false }
-        
-        animator.behaviors.forEach {
-            guard let behavior = $0 as? UIAttachmentBehavior, let item = behavior.items.first else { return }
-            update(behavior: behavior, and: item, in: view, for: newBounds)
-            animator.updateItem(usingCurrentState: item)
-        }
-        return view.bounds.width != newBounds.width
-    }
-    
-    private func update(behavior: UIAttachmentBehavior, and item: UIDynamicItem, in view: UICollectionView, for bounds: CGRect) {
-        let delta = CGVector(dx: bounds.origin.x - view.bounds.origin.x, dy: bounds.origin.y - view.bounds.origin.y)
-        let resistance = CGVector(dx: abs(view.panGestureRecognizer.location(in: view).x - behavior.anchorPoint.x) / 1000, dy: abs(view.panGestureRecognizer.location(in: view).y - behavior.anchorPoint.y) / 1000)
-        
-        switch scrollDirection {
-        case .horizontal: item.center.x += delta.dx < 0 ? max(delta.dx, delta.dx * resistance.dx) : min(delta.dx, delta.dx * resistance.dx)
-        case .vertical: item.center.y += delta.dy < 0 ? max(delta.dy, delta.dy * resistance.dy) : min(delta.dy, delta.dy * resistance.dy)
-        @unknown default:
-            item.center.y += delta.dy < 0 ? max(delta.dy, delta.dy * resistance.dy) : min(delta.dy, delta.dy * resistance.dy)
-        }
-        
-        item.center.flooredInPlace()
-    }
+    item.center = floor(item.center)
+  }
 }
 
 extension UIDynamicAnimator {
-    
-    open func addBehavior(_ behavior: UIAttachmentBehavior, _ damping: CGFloat, _ frequency: CGFloat) {
-        behavior.damping = damping
-        behavior.frequency = frequency
-        addBehavior(behavior)
-    }
+  open func addBehavior(_ behavior: UIAttachmentBehavior, _ damping: CGFloat, _ frequency: CGFloat) {
+    behavior.damping = damping
+    behavior.frequency = frequency
+    addBehavior(behavior)
+  }
 }
 
-extension CGPoint {
-    
-    func floored() -> CGPoint {
-        return CGPoint(x: floor(x), y: floor(y))
-    }
-    
-    mutating func flooredInPlace() {
-        self = floored()
-    }
+fileprivate func floor(_ point: CGPoint) -> CGPoint {
+  return CGPoint(x: floor(point.x), y: floor(point.y))
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [X] Works with every `UICollectionView`.
 - [X] Horizontal and vertical scrolling support.
 - [X] Configurable bounce effect.
+- [X] Supports cell size changes
 
 ## Setup
 The only you thing you need to do is import `BouncyLayout`, create an instance and add it to your `UICollectionView`.


### PR DESCRIPTION
- Reduced number of iterations required to prepare layout
- Cache visible indices
- Cache visible cell CGSizes
- Update UIDynamicAnimator on cell size change
- Cleanup private methods and stop leakage of utils
- Remove redundant layout invalidations